### PR TITLE
Make cargo check and clippy happy

### DIFF
--- a/rsget_cli/src/main.rs
+++ b/rsget_cli/src/main.rs
@@ -1,18 +1,16 @@
 use std::boxed::Box;
-use tokio::fs::File;
 use std::path::Path;
 use std::process::Command;
+use tokio::fs::File;
 
 use flexi_logger::{opt_format, Logger};
-use rsget_lib::{Streamable, Status};
+use log::warn;
+use rsget_lib::{Status, Streamable};
 use structopt::StructOpt;
-use tokio::prelude::*;
-use log::{warn, info};
 
+use rsget_lib::utils::error::RsgetError;
 use rsget_lib::utils::error::StreamError;
 use rsget_lib::utils::stream_type_to_url;
-use rsget_lib::utils::error::RsgetError;
-
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "rsget")]
@@ -45,8 +43,7 @@ async fn main() -> Result<(), StreamError> {
         Status::Online => (),
         Status::Unknown => {
             warn!("Not sure if stream is online, but will try");
-            ()
-        },
+        }
     }
 
     if opt.info {

--- a/rsget_lib/src/lib.rs
+++ b/rsget_lib/src/lib.rs
@@ -6,16 +6,11 @@ extern crate log;
 #[macro_use]
 extern crate serde_derive;
 
-use crate::utils::error::RsgetError;
 use crate::utils::error::StreamError;
 
 use std::boxed::Box;
-use std::io::Write;
 
-use stream_lib::Stream;
 use stream_lib::StreamType;
-
-use reqwest::Client as ReqwestClient;
 
 use async_trait::async_trait;
 

--- a/rsget_lib/src/plugins/afreeca.rs
+++ b/rsget_lib/src/plugins/afreeca.rs
@@ -1,4 +1,4 @@
-use crate::{Streamable, Status};
+use crate::{Status, Streamable};
 use regex::Regex;
 
 use crate::utils::error::RsgetError;
@@ -7,7 +7,6 @@ use crate::utils::error::StreamError;
 use chrono::prelude::*;
 
 use reqwest::header::REFERER;
-use reqwest::Client as RClient;
 
 use stream_lib::StreamType;
 
@@ -120,11 +119,12 @@ async fn get_hls_key(
         quality: "original".to_string(),
         _type: "pwd".to_string(),
     };
-    let mut res = client
+    let res = client
         .post("http://live.afreecatv.com:8057/afreeca/player_live_api.php")
         .header(REFERER, url)
         .form(&data)
-        .send().await?;
+        .send()
+        .await?;
     let json: AfreecaChannelInfo<AfreecaHlsKey> = res.json().await?;
     if json.CHANNEL.RESULT != 1 {
         return Err(StreamError::Rsget(RsgetError::new(
@@ -149,10 +149,11 @@ impl Streamable for Afreeca {
                 mode: String::from("landing"),
                 player_type: String::from("html5"),
             };
-            let mut res = client
+            let res = client
                 .post("http://live.afreecatv.com:8057/afreeca/player_live_api.php")
                 .form(&data)
-                .send().await?;
+                .send()
+                .await?;
             debug!("Gettin channel_info");
             let json_str = res.text().await?;
             debug!("{}", json_str);
@@ -171,7 +172,8 @@ impl Streamable for Afreeca {
             url.clone(),
             String::from(&cap[1]),
             ci.CHANNEL.BNO.clone(),
-        ).await?;
+        )
+        .await?;
         let json_url = format!(
             "{}/broad_stream_assign.html?return_type={}&broad_key={}",
             ci.CHANNEL.RMD.clone(),
@@ -186,7 +188,7 @@ impl Streamable for Afreeca {
             afreeca_info: ci,
             hls_key,
             stream_info,
-            client: client,
+            client,
         };
         debug!("{:#?}", retval);
         Ok(Box::new(retval))
@@ -248,5 +250,4 @@ impl Streamable for Afreeca {
             self.get_ext().await.unwrap(),
         ))
     }
-
 }

--- a/rsget_lib/src/utils/error.rs
+++ b/rsget_lib/src/utils/error.rs
@@ -87,27 +87,22 @@ pub enum StreamError {
 
 impl Display for StreamError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str(self.description())
-    }
-}
-
-impl StdError for StreamError {
-    fn description(&self) -> &str {
-        match *self {
-            StreamError::Fmt(ref inner) => inner.description(),
-            StreamError::Json(ref inner) => inner.description(),
-            StreamError::Rsget(ref inner) => inner.description(),
-            StreamError::Io(ref inner) => inner.description(),
-            StreamError::Uri(ref inner) => inner.description(),
-            StreamError::ToStr(ref inner) => inner.description(),
-            StreamError::Http(ref inner) => inner.description(),
-            StreamError::Hls(ref inner) => inner.description(),
-            StreamError::Utf8(ref inner) => inner.description(),
-            StreamError::UrlEnc(ref inner) => inner.description(),
-            StreamError::Reqwest(ref inner) => inner.description(),
-            StreamError::Regex(ref inner) => inner.description(),
-            StreamError::Stream(ref inner) => inner.description(),
-        }
+        let error_str = match *self {
+            StreamError::Fmt(ref inner) => inner.to_string(),
+            StreamError::Json(ref inner) => inner.to_string(),
+            StreamError::Rsget(ref inner) => inner.to_string(),
+            StreamError::Io(ref inner) => inner.to_string(),
+            StreamError::Uri(ref inner) => inner.to_string(),
+            StreamError::ToStr(ref inner) => inner.to_string(),
+            StreamError::Http(ref inner) => inner.to_string(),
+            StreamError::Hls(ref inner) => inner.to_string(),
+            StreamError::Utf8(ref inner) => inner.to_string(),
+            StreamError::UrlEnc(ref inner) => inner.to_string(),
+            StreamError::Reqwest(ref inner) => inner.to_string(),
+            StreamError::Regex(ref inner) => inner.to_string(),
+            StreamError::Stream(ref inner) => inner.to_string(),
+        };
+        f.write_str(&error_str)
     }
 }
 

--- a/rsget_lib/src/utils/sites.rs
+++ b/rsget_lib/src/utils/sites.rs
@@ -10,8 +10,6 @@ use crate::utils::error::StreamError;
 use crate::Streamable;
 use regex::Regex;
 
-use reqwest;
-
 pub async fn get_site(input: &str) -> Result<Box<dyn Streamable + Send>, StreamError> {
     match _get_site(input).await {
         Ok(s) => Ok(s),

--- a/stream_lib/src/error.rs
+++ b/stream_lib/src/error.rs
@@ -4,8 +4,8 @@ use std::{
     error::Error as StdError,
     fmt::{Display, Formatter, Result as FmtResult},
 };
-use url::ParseError;
 use tokio::io::Error as TokioIoError;
+use url::ParseError;
 
 #[derive(Debug)]
 pub enum Error {
@@ -16,7 +16,7 @@ pub enum Error {
     /// Url error.
     Url(ParseError),
     /// Tokio IO error
-    TIO(TokioIoError)
+    TIO(TokioIoError),
 }
 
 impl From<HlsError> for Error {
@@ -49,4 +49,4 @@ impl Display for Error {
     }
 }
 
-impl StdError for Error { }
+impl StdError for Error {}

--- a/stream_lib/src/hls.rs
+++ b/stream_lib/src/hls.rs
@@ -64,8 +64,8 @@ impl HlsDownloader {
                 }
                 HlsQueue::StreamOver => {
                     warn!("Stream ended");
-                    break
-                },
+                    break;
+                }
             }
         }
 
@@ -112,7 +112,7 @@ impl HlsWatch {
                 // There have either been errors or no new segments
                 // for `HLS_MAX_RETRIES` times the segment duration given
                 // in the m3u8 playlist file.
-                if let Err(_) = self.tx.send(HlsQueue::StreamOver) {
+                if self.tx.send(HlsQueue::StreamOver).is_err() {
                     return Err(Error::TIO(std::io::Error::last_os_error()));
                 };
                 break;
@@ -199,7 +199,7 @@ impl HlsWatch {
                     if !(e.contains("preloading")) {
                         info!("[HLS] Adds {}!", url_formatted);
                         // Add the segment to the queue.
-                        if let Err(_) = self.tx.send(HlsQueue::Url(url_formatted)) {
+                        if self.tx.send(HlsQueue::Url(url_formatted)).is_err() {
                             return Err(Error::TIO(std::io::Error::last_os_error()));
                         };
                     }

--- a/stream_lib/src/lib.rs
+++ b/stream_lib/src/lib.rs
@@ -5,9 +5,9 @@
 extern crate log;
 
 mod error;
-pub mod stream;
 pub mod hls;
 pub mod named_hls;
+pub mod stream;
 
 pub use crate::error::Error;
 pub use crate::hls::HlsDownloader;


### PR DESCRIPTION
Remove the deprecated Error::description usages to to_string() as recommended.
Turn redundant if let Err(_) usages to if <>.is_err().