### PR TITLE
Use patricia-tree-sets for saving seen hls segments

### DIFF
--- a/stream_lib/Cargo.toml
+++ b/stream_lib/Cargo.toml
@@ -16,6 +16,7 @@ log = "^0.4"
 url = "2"
 futures-util = "0.3.1"
 tokio = { version = "0.2", features = ["full"] }
+patricia_tree = "0.2.0"
 
 [dependencies.indicatif]
 optional = true

--- a/stream_lib/src/hls.rs
+++ b/stream_lib/src/hls.rs
@@ -14,7 +14,8 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use futures_util::StreamExt;
 
-use std::collections::HashSet;
+use patricia_tree::PatriciaSet;
+
 #[cfg(feature = "spinner")]
 use std::sync::Arc;
 use std::time::Duration;
@@ -149,7 +150,7 @@ struct HlsWatch {
     tx: UnboundedSender<HlsQueue>,
     request: Request,
     http: ReqwestClient,
-    links: HashSet<String>,
+    links: PatriciaSet,
     master_url: Url,
 }
 
@@ -166,7 +167,7 @@ impl HlsWatch {
                 tx,
                 request,
                 http,
-                links: HashSet::new(),
+                links: PatriciaSet::new(),
                 master_url,
             },
             rx,

--- a/stream_lib/src/named_hls.rs
+++ b/stream_lib/src/named_hls.rs
@@ -15,7 +15,8 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use futures_util::StreamExt;
 
-use std::collections::HashSet;
+use patricia_tree::PatriciaSet;
+
 use std::time::Duration;
 
 #[cfg(feature = "spinner")]
@@ -145,7 +146,7 @@ struct NamedHlsWatch {
     tx: UnboundedSender<HlsQueue>,
     request: Request,
     http: ReqwestClient,
-    links: HashSet<String>,
+    links: PatriciaSet,
     master_url: Url,
     name: String,
 }
@@ -167,7 +168,7 @@ impl NamedHlsWatch {
                 tx,
                 request,
                 http,
-                links: HashSet::new(),
+                links: PatriciaSet::new(),
                 master_url,
                 name,
             },


### PR DESCRIPTION
Patricia trees are more memory efficient than other types of sets,
epsecially if they share a prefix a lot of the time.