### PR TITLE
Fix dependencies so we don't pull in openssl

### DIFF
--- a/rsget_cli/Cargo.toml
+++ b/rsget_cli/Cargo.toml
@@ -16,9 +16,21 @@ tracing = "0.1"
 tracing-subscriber = "0.3.18"
 clap = { version = "4.4.11", features = ["derive"] }
 tokio = { version = "1", features = ["fs", "rt-multi-thread", "io-util", "io-std"] }
-reqwest = "0.12"
+reqwest = { version = "0.12", default-features = false}
 indicatif = "0.17.7"
 futures-util = "0.3.30"
+
+[features]
+# Default to rustls so we don't pull in openssl
+default = ["rustls-tls"]
+rustls-tls = [
+  "reqwest/rustls-tls",
+  "reqwest/rustls-tls-webpki-roots",
+]
+native-tls = [
+  "reqwest/native-tls",
+  "reqwest/rustls-tls-native-roots",
+]
 
 [[bin]]
 name = "rsget"

--- a/rsget_lib/Cargo.toml
+++ b/rsget_lib/Cargo.toml
@@ -19,7 +19,7 @@ regex = "1.10"
 http = "0.2.11"
 chrono = "0.4"
 hls_m3u8 = "0.4"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
 rand = { version ="0.8", features = ["small_rng"] }
 async-trait = "0.1"
 webbrowser = "0.8"
@@ -29,3 +29,15 @@ default-features = false
 version = "0.5.0"
 path = "../stream_lib"
 features = []
+
+[features]
+# Default to rustls so we don't pull in openssl
+default = ["rustls-tls"]
+rustls-tls = [
+  "reqwest/rustls-tls",
+  "reqwest/rustls-tls-webpki-roots",
+]
+native-tls = [
+  "reqwest/native-tls",
+  "reqwest/rustls-tls-native-roots",
+]

--- a/rsget_lib/src/plugins/mod.rs
+++ b/rsget_lib/src/plugins/mod.rs
@@ -1,8 +1,8 @@
 mod afreeca;
 mod bilibili;
 mod dlive;
-mod drdk;
 mod twitch;
+mod drdk;
 mod vlive;
 
 pub use afreeca::Afreeca;

--- a/rsget_lib/src/plugins/twitch.rs
+++ b/rsget_lib/src/plugins/twitch.rs
@@ -116,7 +116,7 @@ impl Streamable for Twitch {
                     e
                 })?;
 
-            match payload.data.get(0) {
+            match payload.data.first() {
                 Some(data) => Ok(data.title.clone()),
                 None => Err(StreamError::Rsget(RsgetError::new(
                     "[Twitch] User is offline",
@@ -177,7 +177,7 @@ impl Streamable for Twitch {
             .text()
             .await?;
         let playlist = MasterPlaylist::try_from(playlist_res.as_str())?;
-        let qu_name = playlist.media.get(0).unwrap().name();
+        let qu_name = playlist.media.first().unwrap().name();
 
         Ok(stream_lib::download_hls_named(
             self.client.clone(),

--- a/rsget_lib/src/plugins/vlive.rs
+++ b/rsget_lib/src/plugins/vlive.rs
@@ -131,7 +131,7 @@ impl Streamable for Vlive {
         let info = page_req.json::<VideoInfo>().await?;
         let stream_url = info
             .streams
-            .get(0)
+            .first()
             .map(|stream| format!("{}?{}={}", stream.source, stream.key.name, stream.key.value));
 
         let mut videos = info.videos.list;

--- a/rsget_lib/src/utils/sites.rs
+++ b/rsget_lib/src/utils/sites.rs
@@ -4,8 +4,8 @@ use crate::plugins::{
     mixer::Mixer, tiktok::TikTok, twitch::Twitch, vlive::Vlive,
 };
 */
-use crate::plugins::{Afreeca, Bilibili, DLive, Drdk, Twitch, Vlive};
 //use crate::plugins::{Afreeca, Bilibili, DLive, Twitch, Vlive};
+use crate::plugins::{Afreeca, Bilibili, DLive, Drdk, Twitch, Vlive};
 use crate::utils::error::RsgetError;
 use crate::utils::error::StreamError;
 use crate::utils::error::StreamResult;

--- a/stream_lib/Cargo.toml
+++ b/stream_lib/Cargo.toml
@@ -11,18 +11,27 @@ repository = "https://github.com/Erk-/rsget/tree/master/stream_lib"
 
 [dependencies]
 hls_m3u8 = "0.4.1"
-reqwest = { version = "0.12.5", features = ["stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 tracing = "0.1.40"
 url = "2.5.0"
 futures-util = "0.3.30"
-tokio = { version = "1.35.1", default-features = false, features = ["rt", "sync", "time"] }
+tokio = { version = "1.38.0", default-features = false, features = ["rt", "sync", "time"] }
 patricia_tree = "0.8.0"
 futures-core = "0.3.30"
 bytes = "1.5.0"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"
-tokio = { version = "1.35.1", default-features = false, features = ["fs", "rt", "sync", "time", "macros"] }
+tokio = { version = "1.38", default-features = false, features = ["fs", "rt", "sync", "time", "macros"] }
 
 [features]
-default = []
+# Default to rustls so we don't pull in openssl
+default = ["rustls-tls"]
+rustls-tls = [
+  "reqwest/rustls-tls",
+  "reqwest/rustls-tls-webpki-roots",
+]
+native-tls = [
+  "reqwest/native-tls",
+  "reqwest/rustls-tls-native-roots",
+]


### PR DESCRIPTION
* I feature gated native-tls versus rust-tls and defaulted to rust-tls so that we don't force pulling in openssl.
* I also had to remove Drdk library that doesn't seem to exist?
* Updated tokio as well.