### PR TITLE
chore: update dependencies and move to 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,18 @@ members = [
     "rsget_cli",
     "stream_lib",
 ]
-resolver = "2"
+resolver = "3"
+package.edition = "2024"
+
+[workspace.dependencies]
+tracing = "0.1.44"
+tracing-subscriber = "0.3.23"
+tokio = { version = "1.52.3", default-features = false }
+hls_m3u8 = "0.7.0"
+reqwest = { version = "0.13.3", default-features = false }
+futures-util = "0.3.32"
+stream_lib = { version = "0.5", path = "./stream_lib", default-features = false }
+rsget_lib = { version = "0.3", path = "./rsget_lib" }
 
 [profile.release]
 panic = "abort"

--- a/rsget_cli/Cargo.toml
+++ b/rsget_cli/Cargo.toml
@@ -13,12 +13,12 @@ repository = "https://github.com/Erk-/rsget/tree/master/rsget_cli"
 rsget_lib = { version = "0.3", path = "../rsget_lib" }
 stream_lib = { version = "0.5", path = "../stream_lib" }
 tracing = "0.1"
-tracing-subscriber = "0.3.18"
-clap = { version = "4.4.11", features = ["derive"] }
+tracing-subscriber = "0.3.22"
+clap = { version = "4.5.60", features = ["derive"] }
 tokio = { version = "1", features = ["fs", "rt-multi-thread", "io-util", "io-std"] }
 reqwest = { version = ">=0.13", default-features = false}
-indicatif = "0.17.7"
-futures-util = "0.3.30"
+indicatif = "0.18.4"
+futures-util = "0.3.32"
 
 [features]
 # Default to rustls so we don't pull in openssl

--- a/rsget_cli/Cargo.toml
+++ b/rsget_cli/Cargo.toml
@@ -16,20 +16,18 @@ tracing = "0.1"
 tracing-subscriber = "0.3.18"
 clap = { version = "4.4.11", features = ["derive"] }
 tokio = { version = "1", features = ["fs", "rt-multi-thread", "io-util", "io-std"] }
-reqwest = { version = "0.12", default-features = false}
+reqwest = { version = ">=0.13", default-features = false}
 indicatif = "0.17.7"
 futures-util = "0.3.30"
 
 [features]
 # Default to rustls so we don't pull in openssl
-default = ["rustls-tls"]
-rustls-tls = [
-  "reqwest/rustls-tls",
-  "reqwest/rustls-tls-webpki-roots",
+default = ["rustls"]
+rustls = [
+  "reqwest/rustls",
 ]
 native-tls = [
   "reqwest/native-tls",
-  "reqwest/rustls-tls-native-roots",
 ]
 
 [[bin]]

--- a/rsget_cli/Cargo.toml
+++ b/rsget_cli/Cargo.toml
@@ -4,21 +4,21 @@ version = "0.1.5"
 authors = ["Valdemar Erk <valdemar@erk.io>"]
 description = "Tool to get information about and download livestreams"
 license = "ISC"
-edition = "2021"
+edition.workspace = true
 documentation = "https://docs.rs/rsget"
 homepage = "https://github.com/Erk-/rsget"
 repository = "https://github.com/Erk-/rsget/tree/master/rsget_cli"
 
 [dependencies]
-rsget_lib = { version = "0.3", path = "../rsget_lib" }
-stream_lib = { version = "0.5", path = "../stream_lib" }
-tracing = "0.1"
-tracing-subscriber = "0.3.22"
+rsget_lib.workspace = true
+stream_lib.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 clap = { version = "4.5.60", features = ["derive"] }
-tokio = { version = "1", features = ["fs", "rt-multi-thread", "io-util", "io-std"] }
-reqwest = { version = ">=0.13", default-features = false}
+tokio = { workspace = true, features = ["fs", "rt-multi-thread", "io-util", "io-std"] }
+reqwest = { workspace = true, default-features = false }
 indicatif = "0.18.4"
-futures-util = "0.3.32"
+futures-util.workspace = true
 
 [features]
 # Default to rustls so we don't pull in openssl

--- a/rsget_lib/Cargo.toml
+++ b/rsget_lib/Cargo.toml
@@ -4,31 +4,26 @@ version = "0.3.0"
 authors = ["Valdemar Erk <valdemar@erk.io>"]
 description = "Library to get information about and download livestreams"
 license = "ISC"
-edition = "2021"
+edition.workspace = true
 documentation = "https://docs.rs/rsget_lib"
 homepage = "https://github.com/Erk-/rsget"
 repository = "https://github.com/Erk-/rsget/tree/master/rsget_lib"
 
 [dependencies]
-tracing = "0.1"
-serde = "^1.0"
+tracing.workspace = true
+serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 regex = "1.12"
 http = "1.4"
 chrono = "0.4"
-hls_m3u8 = "0.5"
-reqwest = { version = ">=0.13", default-features = false, features = ["form", "json", "query"] }
+hls_m3u8.workspace = true
+reqwest = { workspace = true, default-features = false, features = ["form", "json", "query"] }
 rand = "0.10"
 async-trait = "0.1"
 webbrowser = "1.1"
-
-[dependencies.stream_lib]
-default-features = false
-version = "0.5.0"
-path = "../stream_lib"
-features = []
+stream_lib = { workspace = true, default-features = false }
 
 [features]
 # Default to rustls so we don't pull in openssl

--- a/rsget_lib/Cargo.toml
+++ b/rsget_lib/Cargo.toml
@@ -15,14 +15,14 @@ serde = "^1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7"
-regex = "1.10"
-http = "0.2.11"
+regex = "1.12"
+http = "1.4"
 chrono = "0.4"
-hls_m3u8 = "0.4"
+hls_m3u8 = "0.5"
 reqwest = { version = ">=0.13", default-features = false, features = ["form", "json", "query"] }
-rand = { version ="0.8", features = ["small_rng"] }
+rand = "0.10"
 async-trait = "0.1"
-webbrowser = "0.8"
+webbrowser = "1.1"
 
 [dependencies.stream_lib]
 default-features = false

--- a/rsget_lib/Cargo.toml
+++ b/rsget_lib/Cargo.toml
@@ -19,7 +19,7 @@ regex = "1.10"
 http = "0.2.11"
 chrono = "0.4"
 hls_m3u8 = "0.4"
-reqwest = { version = "0.12", default-features = false, features = ["json"] }
+reqwest = { version = ">=0.13", default-features = false, features = ["form", "json", "query"] }
 rand = { version ="0.8", features = ["small_rng"] }
 async-trait = "0.1"
 webbrowser = "0.8"
@@ -32,12 +32,10 @@ features = []
 
 [features]
 # Default to rustls so we don't pull in openssl
-default = ["rustls-tls"]
-rustls-tls = [
-  "reqwest/rustls-tls",
-  "reqwest/rustls-tls-webpki-roots",
+default = ["rustls"]
+rustls = [
+  "reqwest/rustls",
 ]
 native-tls = [
   "reqwest/native-tls",
-  "reqwest/rustls-tls-native-roots",
 ]

--- a/rsget_lib/src/plugins/twitch.rs
+++ b/rsget_lib/src/plugins/twitch.rs
@@ -4,7 +4,7 @@ use std::env;
 
 use chrono::prelude::*;
 use hls_m3u8::MasterPlaylist;
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{rngs::SmallRng, Rng, RngExt, SeedableRng};
 use regex::Regex;
 
 use std::{
@@ -81,10 +81,7 @@ impl Streamable for Twitch {
             Err(_) => String::from(TWITCH_CLIENT_ID),
         };
 
-        let access_token = match env::var("RSGET_TWITCH_ACCESS_TOKEN") {
-            Ok(val) => Some(val),
-            Err(_) => None,
-        };
+        let access_token = env::var("RSGET_TWITCH_ACCESS_TOKEN").ok();
 
         let twitch = Twitch {
             client,
@@ -167,7 +164,7 @@ impl Streamable for Twitch {
             .as_secs();
         let mut rng = SmallRng::seed_from_u64(time);
         let playlist_url = format!("https://usher.ttvnw.net/api/channel/hls/{}.m3u8?player=twitchweb&token={}&sig={}&allow_audio_only=true&allow_source=true&type=any&p={}",
-                                    self.username, acs.token, acs.sig, rng.gen_range(1..=999_999));
+                                    self.username, acs.token, acs.sig, rng.random_range(1..=999_999));
 
         let playlist_res = self
             .client

--- a/rsget_lib/src/plugins/vlive.rs
+++ b/rsget_lib/src/plugins/vlive.rs
@@ -72,7 +72,7 @@ impl Streamable for Vlive {
             .ok_or_else(|| StreamError::Rsget(RsgetError::new("No capture found")))?[1]
             .to_string();
 
-        let page_req = http.get(&format!("https://global.apis.naver.com/rmcnmv/rmcnmv/vod_play_videoInfo.json?key={}&videoId={}", key, id)).send().await?;
+        let page_req = http.get(format!("https://global.apis.naver.com/rmcnmv/rmcnmv/vod_play_videoInfo.json?key={}&videoId={}", key, id)).send().await?;
 
         // all these structs are quite excessive for what we actually need but i want to be ready for the "Quality Update"
         // Currently this backend just chooses the video with the highest file size, aka most likely to be highest quality

--- a/stream_lib/Cargo.toml
+++ b/stream_lib/Cargo.toml
@@ -4,25 +4,25 @@ version = "0.5.2"
 authors = ["Valdemar Erk <cargo@erk.dev>"]
 description = "Tool to download differnt types of streams"
 license = "ISC"
-edition = "2021"
+edition.workspace = true
 documentation = "https://docs.rs/stream_lib"
 homepage = "https://github.com/Erk-/rsget"
 repository = "https://github.com/Erk-/rsget/tree/master/stream_lib"
 
 [dependencies]
-hls_m3u8 = "0.5.1"
-reqwest = { version = ">=0.13", default-features = false, features = ["stream"] }
-tracing = "0.1.44"
+hls_m3u8.workspace = true
+reqwest = { workspace = true, default-features = false, features = ["stream"] }
+tracing.workspace = true
 url = "2.5.8"
-futures-util = "0.3.32"
-tokio = { version = "1.49.0", default-features = false, features = ["rt", "sync", "time"] }
+futures-util.workspace = true
+tokio = { workspace = true, default-features = false, features = ["rt", "sync", "time"] }
 patricia_tree = "0.10.1"
 futures-core = "0.3.32"
 bytes = "1.11.1"
 
 [dev-dependencies]
-tracing-subscriber = "0.3.22"
-tokio = { version = "1.49", default-features = false, features = ["fs", "rt", "sync", "time", "macros"] }
+tracing-subscriber.workspace = true
+tokio = { workspace = true, default-features = false, features = ["fs", "rt", "sync", "time", "macros"] }
 
 [features]
 # Default to rustls so we don't pull in openssl

--- a/stream_lib/Cargo.toml
+++ b/stream_lib/Cargo.toml
@@ -26,10 +26,9 @@ tokio = { version = "1.38", default-features = false, features = ["fs", "rt", "s
 
 [features]
 # Default to rustls so we don't pull in openssl
-default = ["rustls-tls"]
-rustls-tls = [
-  "reqwest/rustls-tls",
-  "reqwest/rustls-tls-webpki-roots",
+default = ["rustls"]
+rustls = [
+  "reqwest/rustls",
 ]
 native-tls = [
   "reqwest/native-tls",

--- a/stream_lib/Cargo.toml
+++ b/stream_lib/Cargo.toml
@@ -10,19 +10,19 @@ homepage = "https://github.com/Erk-/rsget"
 repository = "https://github.com/Erk-/rsget/tree/master/stream_lib"
 
 [dependencies]
-hls_m3u8 = "0.4.1"
-reqwest = { version = ">=0.12", default-features = false, features = ["stream"] }
-tracing = "0.1.40"
-url = "2.5.0"
-futures-util = "0.3.30"
-tokio = { version = "1.38.0", default-features = false, features = ["rt", "sync", "time"] }
-patricia_tree = "0.8.0"
-futures-core = "0.3.30"
-bytes = "1.5.0"
+hls_m3u8 = "0.5.1"
+reqwest = { version = ">=0.13", default-features = false, features = ["stream"] }
+tracing = "0.1.44"
+url = "2.5.8"
+futures-util = "0.3.32"
+tokio = { version = "1.49.0", default-features = false, features = ["rt", "sync", "time"] }
+patricia_tree = "0.10.1"
+futures-core = "0.3.32"
+bytes = "1.11.1"
 
 [dev-dependencies]
-tracing-subscriber = "0.3.18"
-tokio = { version = "1.38", default-features = false, features = ["fs", "rt", "sync", "time", "macros"] }
+tracing-subscriber = "0.3.22"
+tokio = { version = "1.49", default-features = false, features = ["fs", "rt", "sync", "time", "macros"] }
 
 [features]
 # Default to rustls so we don't pull in openssl

--- a/stream_lib/Cargo.toml
+++ b/stream_lib/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/Erk-/rsget/tree/master/stream_lib"
 
 [dependencies]
 hls_m3u8 = "0.4.1"
-reqwest = { version = "0.12", default-features = false, features = ["stream"] }
+reqwest = { version = ">=0.12", default-features = false, features = ["stream"] }
 tracing = "0.1.40"
 url = "2.5.0"
 futures-util = "0.3.30"

--- a/stream_lib/src/hls/mod.rs
+++ b/stream_lib/src/hls/mod.rs
@@ -132,10 +132,9 @@ async fn bytes_forwarder(
                     Some(TIMEOUT),
                 )
                 .await
+                    && let Err(error) = event_tx.send(Event::Error { error })
                 {
-                    if let Err(error) = event_tx.send(Event::Error { error }) {
-                        warn!("Could not send event: {}", error);
-                    };
+                    warn!("Could not send event: {}", error);
                 }
             }
             HlsQueue::StreamOver => {
@@ -184,14 +183,17 @@ pub(crate) async fn download_to_file(
 }
 
 pub fn clone_request(request: &Request, timeout: Duration) -> Request {
-    if let Some(mut r) = request.try_clone() {
-        *r.timeout_mut() = Some(timeout);
-        r
-    } else {
-        warn!("[HLS] body not able to be cloned only clones headers.");
-        let mut r = Request::new(Method::GET, request.url().clone());
-        *r.headers_mut() = request.headers().clone();
-        *r.timeout_mut() = Some(timeout);
-        r
+    match request.try_clone() {
+        Some(mut r) => {
+            *r.timeout_mut() = Some(timeout);
+            r
+        }
+        _ => {
+            warn!("[HLS] body not able to be cloned only clones headers.");
+            let mut r = Request::new(Method::GET, request.url().clone());
+            *r.headers_mut() = request.headers().clone();
+            *r.timeout_mut() = Some(timeout);
+            r
+        }
     }
 }

--- a/stream_lib/src/hls/named_watch.rs
+++ b/stream_lib/src/hls/named_watch.rs
@@ -248,7 +248,7 @@ impl NamedHlsWatch {
                     };
 
                     // Check that the filter runs.
-                    if self.filter.map_or(true, |f| f(&e)) {
+                    if self.filter.is_none_or(|f| f(&e)) {
                         debug!("[HLS] Adds {}!", url_formatted);
                         // Add the segment to the queue.
                         if self.tx.send(HlsQueue::Url(url_formatted)).is_err() {

--- a/stream_lib/src/hls/watch.rs
+++ b/stream_lib/src/hls/watch.rs
@@ -124,7 +124,7 @@ impl HlsWatch {
                     };
 
                     // Check that the filter runs.
-                    if self.filter.map_or(true, |f| f(e)) {
+                    if self.filter.is_none_or(|f| f(e)) {
                         debug!("[HLS] Adds {}!", url_formatted);
                         // Add the segment to the queue.
                         if self.tx.send(HlsQueue::Url(url_formatted)).is_err() {


### PR DESCRIPTION
I also moved a few dependencies that were referenced more than once to be declared in the workspace + ran ```cargo clippy``` for linting